### PR TITLE
fixes typo in 'Single Route' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ function mainHandler( $name ){
 }
 
 Link::all(array(
-    '/{s}' => 'mainHandler', 'Main', 'beforHandler'
+    '/{s}' => ['mainHandler', 'Main', 'beforHandler']
     ));
 ``` 
 


### PR DESCRIPTION
Second last line of code changes. There should be an array in value of key-value pair.