### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ I simply occured
 
 I simply occured after.
 
-###Single Route
+### Single Route
 
 You can add a before (middle) handler to a specific route, just pass the before handler to routes array as third parameters. The wildcards extracted from route will be passed to to before handler and if it return some array, this array will be passed further to main handler but if not the original extracted wildcards would be passed away. Make sure you return an array from before handler.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
